### PR TITLE
56/add exclude site filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Once you have that installed you can run `npm run dev` to start up the app. This
 ### Working on an issue
 
 - When you select an issue, make sure to assign it to yourself to avoid someone else picking it up and duplicating work. Also go to the project board and move it to 'In Progress'
-- Create a feature branch from `main`. Name your branch starting with the issue number then a little description of what the branch is about separated by a '/', for example '23/take-over-the-world'
+- Create a feature branch from `dev`. Name your branch starting with the issue number then a little description of what the branch is about separated by a '/', for example '23/take-over-the-world'
 - Your commits should be structured and meaningful inline with [this convention](https://dev.to/bhekanik/supercharge-your-git-history-with-better-commit-messages-32fk).
 - Refactor your commits to clean them up (if needed).
 - Always rebase your work before opening a PR.

--- a/src/lib/app/types/filters.ts
+++ b/src/lib/app/types/filters.ts
@@ -7,6 +7,7 @@ export type FilterType =
 	| 'DateBefore'
 	| 'Exact'
 	| 'Exclude'
+	| 'ExcludeSite'
 	| 'File Type'
 	| 'Link'
 	| 'Locale'

--- a/src/lib/components/Filters/Bing.svelte
+++ b/src/lib/components/Filters/Bing.svelte
@@ -6,6 +6,7 @@
 	import Safe from '$lib/components/Filters/Common/Safe.svelte';
 	import SiteFilter from '$lib/components/Filters/Common/Site.svelte';
 	import SynonymsFilter from '$lib/components/Filters/Common/Synonyms.svelte';
+	import ExcludeSite from './Common/ExcludeSite.svelte';
 </script>
 
 <h2 class="text-gray-300">Only return pages...</h2>
@@ -13,6 +14,7 @@
 <Exact />
 <ExcludeFilter />
 <SiteFilter />
+<ExcludeSite />
 <FileTypeFilter />
 <!-- <LinkFilter /> -->
 <RelatedFilter />

--- a/src/lib/components/Filters/Common/ExcludeSite.svelte
+++ b/src/lib/components/Filters/Common/ExcludeSite.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import FilterBase from '$lib/components/Filters/Base/Base.svelte';
+	import { queryStore } from '$lib/stores';
+
+	const handleInput = (e: Event) => {
+		const value = (e.target as HTMLInputElement).value;
+		queryStore.update((currentQuery) => {
+			const newQuery = { ...currentQuery };
+			newQuery.filters.excludeSite = {
+				type: 'ExcludeSite',
+				value,
+				formatted: `-site:${encodeURIComponent(value.trim())}`
+			};
+			return newQuery;
+		});
+	};
+</script>
+
+<FilterBase
+	on:input={handleInput}
+	type="ExcludeSite"
+	hasInput
+	label="... without any results from this website"
+	textInputPlaceholder="Website to exclude (example: cnn.com)"
+/>

--- a/src/lib/components/Filters/Common/ExcludeSite.svelte
+++ b/src/lib/components/Filters/Common/ExcludeSite.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import FilterBase from '$lib/components/Filters/Base/Base.svelte';
 	import { queryStore } from '$lib/stores';
+	import { listCreateParams, QueryKeys } from '../utils/listApplyOperator';
 
 	const handleInput = (e: Event) => {
 		const value = (e.target as HTMLInputElement).value;
@@ -9,7 +10,7 @@
 			newQuery.filters.excludeSite = {
 				type: 'ExcludeSite',
 				value,
-				formatted: `-site:${encodeURIComponent(value.trim())}`
+				formatted: listCreateParams(value, QueryKeys.excludeSite)
 			};
 			return newQuery;
 		});
@@ -20,6 +21,6 @@
 	on:input={handleInput}
 	type="ExcludeSite"
 	hasInput
-	label="... without any results from this website"
-	textInputPlaceholder="Website to exclude (example: cnn.com)"
+	label="... excluding results from any of these websites"
+	textInputPlaceholder="Websites to exclude (example: cnn.com bbc.com)"
 />

--- a/src/lib/components/Filters/DuckDuckGo.svelte
+++ b/src/lib/components/Filters/DuckDuckGo.svelte
@@ -5,6 +5,7 @@
 	import RelatedFilter from '$lib/components/Filters/Common/Related.svelte';
 	import SiteFilter from '$lib/components/Filters/Common/Site.svelte';
 	import SynonymsFilter from '$lib/components/Filters/Common/Synonyms.svelte';
+	import ExcludeSite from './Common/ExcludeSite.svelte';
 </script>
 
 <h2 class="text-gray-300">Only return pages...</h2>
@@ -12,6 +13,7 @@
 <Exact />
 <ExcludeFilter />
 <SiteFilter />
+<ExcludeSite />
 <FileTypeFilter />
 <!-- <LinkFilter /> -->
 <RelatedFilter />

--- a/src/lib/components/Filters/Google.svelte
+++ b/src/lib/components/Filters/Google.svelte
@@ -15,6 +15,7 @@
 	import Rights from '$lib/components/Filters/Google/Rights.svelte';
 	import Safe from '$lib/components/Filters/Google/Safe.svelte';
 	import SiteFilter from '$lib/components/Filters/Google/Site.svelte';
+	import ExcludeSite from './Common/ExcludeSite.svelte';
 </script>
 
 <h2 class="text-gray-300">Only return pages...</h2>
@@ -26,6 +27,7 @@
 <PublishLanguage />
 <Content />
 <SiteFilter />
+<ExcludeSite />
 <!-- <DateBefore /> -->
 <!-- <DateAfter /> -->
 <Area />

--- a/src/lib/components/Filters/Yahoo.svelte
+++ b/src/lib/components/Filters/Yahoo.svelte
@@ -5,6 +5,7 @@
 	import RelatedFilter from '$lib/components/Filters/Common/Related.svelte';
 	import SiteFilter from '$lib/components/Filters/Common/Site.svelte';
 	import SynonymsFilter from '$lib/components/Filters/Common/Synonyms.svelte';
+	import ExcludeSite from './Common/ExcludeSite.svelte';
 </script>
 
 <h2 class="text-gray-300">Only return pages...</h2>
@@ -12,6 +13,7 @@
 <Exact />
 <ExcludeFilter />
 <SiteFilter />
+<ExcludeSite />
 <FileTypeFilter />
 <!-- <LinkFilter /> -->
 <RelatedFilter />

--- a/src/lib/components/Filters/utils/formatQuery.ts
+++ b/src/lib/components/Filters/utils/formatQuery.ts
@@ -60,7 +60,7 @@ export const formatQuery = (options?: { query?: Query }): string => {
 
 		const postfix = getPostfix(query);
 
-		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}${
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix} `}${
 			queryParams.trim() ? `&${queryParams}` : ''
 		}`;
 
@@ -78,7 +78,7 @@ export const formatQuery = (options?: { query?: Query }): string => {
 
 		const postfix = getPostfix(query);
 
-		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}${
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix} `}${
 			queryParams.trim() ? `&${queryParams}` : ''
 		}`;
 
@@ -91,7 +91,7 @@ export const formatQuery = (options?: { query?: Query }): string => {
 
 		const postfix = getPostfix(query);
 
-		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}`;
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`} `;
 
 		return formattedQuery;
 	}

--- a/src/lib/components/Filters/utils/formatQuery.ts
+++ b/src/lib/components/Filters/utils/formatQuery.ts
@@ -11,6 +11,7 @@ const queryParamFilters = [
 	'dateBefore',
 	'exact',
 	'exclude',
+	'excludeSite',
 	'fileType',
 	'link',
 	'locale',
@@ -23,6 +24,14 @@ const queryParamFilters = [
 	'site',
 	'sortBy'
 ];
+
+const postFixFilters = ['excludeSite'];
+
+const getPostfix = (query: Query): string =>
+	Object.entries(query.filters)
+		.filter((filter) => postFixFilters.includes(filter[0]))
+		.map((filter) => filter[1].formatted.trim())
+		.join('+');
 
 /**
  * Formats the search input for the search engine according to the provided
@@ -43,11 +52,15 @@ export const formatQuery = (options?: { query?: Query }): string => {
 			.reduce((prev, curr) => `${prev}${curr[1].formatted}`, '');
 
 		const queryParams = Object.entries(query.filters)
-			.filter((filter) => queryParamFilters.includes(filter[0]))
+			.filter(
+				(filter) => queryParamFilters.includes(filter[0]) && !postFixFilters.includes(filter[0])
+			)
 			.map((filter) => filter[1].formatted.trim())
 			.join('&');
 
-		const formattedQuery = `${prefix}${query.search_term}${
+		const postfix = getPostfix(query);
+
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}${
 			queryParams.trim() ? `&${queryParams}` : ''
 		}`;
 
@@ -55,27 +68,30 @@ export const formatQuery = (options?: { query?: Query }): string => {
 	} else if (searchProviderName === 'Bing') {
 		// put the filters together
 		const prefix = Object.entries(query.filters)
-			.filter((filter) => !['save'].includes(filter[0]))
+			.filter((filter) => !['save'].includes(filter[0]) && !postFixFilters.includes(filter[0]))
 			.reduce((prev, curr) => `${prev}${curr[1].formatted}`, '');
 
 		const queryParams = Object.entries(query.filters)
-			.filter((filter) => ['save'].includes(filter[0]))
+			.filter((filter) => ['save'].includes(filter[0]) && !postFixFilters.includes(filter[0]))
 			.map((filter) => filter[1].formatted.trim())
 			.join('&');
 
-		const formattedQuery = `${prefix}${query.search_term}${
+		const postfix = getPostfix(query);
+
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}${
 			queryParams.trim() ? `&${queryParams}` : ''
 		}`;
 
 		return formattedQuery;
 	} else {
 		// put the filters together
-		const prefix = Object.entries(query.filters).reduce(
-			(prev, curr) => `${prev}${curr[1].formatted}`,
-			''
-		);
+		const prefix = Object.entries(query.filters)
+			.filter((filter) => !postFixFilters.includes(filter[0]))
+			.reduce((prev, curr) => `${prev}${curr[1].formatted}`, '');
 
-		const formattedQuery = `${prefix}${query.search_term}`;
+		const postfix = getPostfix(query);
+
+		const formattedQuery = `${prefix}${query.search_term}${postfix.trim() && `+${postfix}`}`;
 
 		return formattedQuery;
 	}

--- a/src/lib/components/Filters/utils/listApplyOperator.ts
+++ b/src/lib/components/Filters/utils/listApplyOperator.ts
@@ -4,7 +4,8 @@ export enum Operator {
 }
 
 export enum QueryKeys {
-	as_eq = 'as_eq'
+	as_eq = 'as_eq',
+	excludeSite = '-site'
 }
 
 export function listApplyOperator(value: string, operator: Operator): string {
@@ -15,6 +16,19 @@ export function listApplyOperator(value: string, operator: Operator): string {
 }
 
 export function listCreateParams(value: string, queryKey: QueryKeys): string {
+	if (queryKey === QueryKeys.excludeSite) {
+		return value
+			.trim()
+			.replace(/\s{2,}/g, ' ')
+			.split(' ')
+			.reduce(
+				(acc, item, index, array) =>
+					`${acc}${`${queryKey}`}:${encodeURIComponent(item.trim())}${
+						index !== array.length - 1 ? '+' : ''
+					}`,
+				''
+			);
+	}
 	return value
 		.trim()
 		.split(' ')

--- a/src/lib/utils/generateAndGo.ts
+++ b/src/lib/utils/generateAndGo.ts
@@ -82,11 +82,11 @@ export const generateQueryUrl = (
 	const formattedQuery = formatQuery({ query });
 
 	if (typeof query.provider.url === 'string') {
-		return `${query.provider.url}${encodeURIComponent(formattedQuery)}`;
+		return `${query.provider.url}${encodeURIComponent(formattedQuery).replace(/%2B/g, '+')}`;
 	} else {
 		const url = [];
 		for (const providerUrl of query.provider.url) {
-			url.push(`${providerUrl}${encodeURIComponent(formattedQuery)}`);
+			url.push(`${providerUrl}${encodeURIComponent(formattedQuery).replace(/%2B/g, '+')}`);
 		}
 		return url;
 	}


### PR DESCRIPTION
#56

## Work Done

Add exclude site filter component, integrate into all search engine providers. Filter can handle multiple urls separated by at least a single space. 


## Notes

Final URI formatting re-introduces any '+' characters that may have been previously converted to unicode within the input. 
Note this behaviour when adding future query Key/Param pairs into the URI. 

## References

Resolves:  #56 
